### PR TITLE
Minor blazeborn tweaks, nerfed Natural Hunter, fixed shulk's minor sound bug

### DIFF
--- a/data/origins/powers/last_ditch_effort.json
+++ b/data/origins/powers/last_ditch_effort.json
@@ -71,6 +71,11 @@
                 {
                     "type": "origins:play_sound",
                     "sound": "minecraft:entity.zombie_villager.cure"
+                },
+                {
+                    "type": "origins:execute_command",
+                    "command": "particle flame ~ ~ ~ 0 1 0 0.75 18",
+                    "permission_level": 4
                 }
             ]
         },

--- a/data/origins/powers/natural_hunter.json
+++ b/data/origins/powers/natural_hunter.json
@@ -306,7 +306,7 @@
                                     "type": "origins:status_effect",
                                     "effect": "minecraft:speed",
                                     "min_amplifier": 0,
-                                    "max_amplifier": 2,
+                                    "max_amplifier": 1,
                                     "min_duration": 0,
                                     "max_duration": 150
                                 },
@@ -498,7 +498,7 @@
                         "type": "origins:status_effect",
                         "effect": "minecraft:speed",
                         "min_amplifier": 0,
-                        "max_amplifier": 2,
+                        "max_amplifier": 1,
                         "min_duration": 0,
                         "max_duration": 150
                     },

--- a/data/origins/powers/natural_hunter.json
+++ b/data/origins/powers/natural_hunter.json
@@ -9,7 +9,8 @@
         "max": 3,
         "hud_render": {
             "should_render": true,
-            "bar_index": 0,
+            "sprite_location": "origins:textures/gui/community/spiderkolo/resource_bar_03.png",
+            "bar_index": 23,
             "condition": {
                 "type": "origins:resource",
                 "resource": "origins:natural_hunter_excitement",
@@ -254,6 +255,113 @@
             "compare_to": 400
         }
     },
+    "punish": {
+        "type": "origins:self_action_on_hit",
+        "entity_action": {
+            "type": "origins:and",
+            "actions": [
+                {
+                    "type": "origins:change_resource",
+                    "resource": "origins:natural_hunter_excitement",
+                    "change": -2
+                },
+                {
+                    "type": "origins:change_resource",
+                    "resource": "origins:natural_hunter_timer",
+                    "change": -40
+                },
+                {
+                    "type": "origins:if_else",
+                    "condition": {
+                        "type": "origins:resource",
+                        "resource": "origins:natural_hunter_excitement",
+                        "comparison": "==",
+                        "compare_to": 0
+                    },
+                    "if_action": {
+                        "type": "origins:and",
+                        "actions": [
+                            {
+                                "type": "origins:change_resource",
+                                "resource": "origins:natural_hunter_limit",
+                                "change": -3
+                            },
+                            {
+                                "type": "origins:change_resource",
+                                "resource": "origins:natural_hunter_timer",
+                                "change": -75
+                            },
+                            {
+                                "type": "origins:change_resource",
+                                "resource": "origins:natural_hunter_cooldown",
+                                "change": -400
+                            },
+                            {
+                                "type": "origins:play_sound",
+                                "sound": "minecraft:entity.cat.hiss"
+                            },
+                            {
+                                "type": "origins:if_else",
+                                "condition": {
+                                    "type": "origins:status_effect",
+                                    "effect": "minecraft:speed",
+                                    "min_amplifier": 0,
+                                    "max_amplifier": 2,
+                                    "min_duration": 0,
+                                    "max_duration": 150
+                                },
+                                "if_action": {
+                                    "type": "origins:clear_effect",
+                                    "effect": "minecraft:speed"
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "damage_condition": {
+            "type": "origins:name",
+            "name": "player"
+        },
+        "target_condition": {
+            "type": "origins:and",
+            "conditions": [
+                {
+                    "type": "origins:entity_type",
+                    "entity_type": "minecraft:cod",
+                    "inverted": true
+                },
+                {
+                    "type": "origins:entity_type",
+                    "entity_type": "minecraft:salmon",
+                    "inverted": true
+                },
+                {
+                    "type": "origins:entity_type",
+                    "entity_type": "minecraft:pufferfish",
+                    "inverted": true
+                },
+                {
+                    "type": "origins:entity_type",
+                    "entity_type": "minecraft:tropical_fish",
+                    "inverted": true
+                },
+                {
+                    "type": "origins:entity_type",
+                    "entity_type": "minecraft:tropical_fish",
+                    "inverted": true
+                }
+            ]
+        },
+        "cooldown": 0,
+        "condition": {
+            "type": "origins:resource",
+            "resource": "origins:natural_hunter_limit",
+            "comparison": ">",
+            "compare_to": 0
+        }
+    },
     "apply_speed": {
         "type": "origins:self_action_on_hit",
         "entity_action": {
@@ -263,23 +371,7 @@
                     "condition": {
                         "type": "origins:resource",
                         "resource": "origins:natural_hunter_excitement",
-                        "comparison": "==",
-                        "compare_to": 3
-                    },
-                    "action": {
-                        "type": "origins:apply_effect",
-                        "effect": {
-                            "effect": "minecraft:speed",
-                            "duration": 150,
-                            "amplifier": 2
-                        }
-                    }
-                },
-                {
-                    "condition": {
-                        "type": "origins:resource",
-                        "resource": "origins:natural_hunter_excitement",
-                        "comparison": "==",
+                        "comparison": ">=",
                         "compare_to": 2
                     },
                     "action": {
@@ -399,6 +491,21 @@
                     "type": "origins:play_sound",
                     "sound": "minecraft:entity.cat.purreow",
                     "volume": 2
+                },
+                {
+                    "type": "origins:if_else",
+                    "condition": {
+                        "type": "origins:status_effect",
+                        "effect": "minecraft:speed",
+                        "min_amplifier": 0,
+                        "max_amplifier": 2,
+                        "min_duration": 0,
+                        "max_duration": 150
+                    },
+                    "if_action": {
+                        "type": "origins:clear_effect",
+                        "effect": "minecraft:speed"
+                    }
                 }
             ]
         },

--- a/data/origins/powers/shell.json
+++ b/data/origins/powers/shell.json
@@ -256,7 +256,7 @@
 				},
 				{
 					"type": "origins:execute_command",
-					"command": "playsound entity.shulker.shoot master Voxaire ~ ~ ~ 1 2",
+					"command": "playsound entity.shulker.shoot master @s ~ ~ ~ 1 2",
 					"permission_level": 4
 				}
 			]

--- a/data/origins/powers/surge.json
+++ b/data/origins/powers/surge.json
@@ -1,7 +1,7 @@
 {
     "type": "origins:multiple",
     "name": "Surge of Fire",
-    "description": "On use the user becomes set on fire and cannot be extinguished by most means for 8 seconds. Due to sudden burst of fire, the user takes 1 heart of damage as recoil on activation (not lethal) and hunger for the ability duration. For a couple seconds you feel slow after the effects wear off.",
+    "description": "On use the user becomes set on fire and cannot be extinguished by most means for 10 seconds. Due to sudden burst of fire, the user takes 1 heart of damage as recoil on activation (not lethal) and hunger for the ability duration. For a couple seconds you feel slow after the effects wear off.",
     "heat": {
         "type": "origins:resource",
         "name": "Heat",
@@ -17,7 +17,7 @@
         "type": "origins:resource",
         "name": "Internal Counter",
         "min": 0,
-        "max": 160,
+        "max": 200,
         "hud_render": {
             "should_render": true,
             "bar_index": 7,
@@ -55,11 +55,11 @@
                 {
                     "type": "origins:change_resource",
                     "resource": "origins:surge_counter",
-                    "change": 160
+                    "change": 200
                 },
                 {
                     "type": "origins:delay",
-                    "ticks": 160,
+                    "ticks": 200,
                     "action": {
                         "type": "origins:change_resource",
                         "resource": "origins:surge_heat",
@@ -69,6 +69,11 @@
                 {
                     "type": "origins:play_sound",
                     "sound": "minecraft:entity.blaze.ambient"
+                },
+                {
+                    "type": "origins:execute_command",
+                    "command": "particle flame ~ ~ ~ 0 1 0 0.1 25",
+                    "permission_level": 4
                 }
             ]
         },
@@ -133,13 +138,13 @@
                         {
                             "type": "origins:change_resource",
                             "resource": "origins:surge_counter",
-                            "change": -160
+                            "change": -200
                         },
                         {
                             "type": "origins:apply_effect",
                             "effect": {
                                 "effect": "minecraft:slowness",
-                                "duration": 60,
+                                "duration": 50,
                                 "amplifier": 1
                             }
                         },
@@ -147,7 +152,7 @@
                             "type": "origins:apply_effect",
                             "effect": {
                                 "effect": "minecraft:mining_fatigue",
-                                "duration": 60,
+                                "duration": 50,
                                 "amplifier": 1
                             }
                         }
@@ -160,7 +165,7 @@
                     {
                         "type": "origins:change_resource",
                         "resource": "origins:surge_counter",
-                        "change": -160
+                        "change": -200
                     },
                     {
                         "type": "origins:change_resource",
@@ -185,7 +190,7 @@
                 {
                     "type": "origins:change_resource",
                     "resource": "origins:surge_counter",
-                    "change": -160
+                    "change": -200
                 }
             ]
         },
@@ -200,7 +205,7 @@
                 {
                     "type": "origins:change_resource",
                     "resource": "origins:surge_counter",
-                    "change": -160
+                    "change": -200
                 },
                 {
                     "type": "origins:change_resource",


### PR DESCRIPTION
-Blazeborn has particle effects when using Surge of Fire and Last Ditch Effort
-Manually activating Surge of Fire now lasts 10 seconds (was 8)
-Fixed shulk not making noise on releasing its shells (use @s not your own name vox!)
-Picked a different sprite for Excitement resource for Natural Hunter power
-If Natural Hunter is active, now once the feline kills an entity, the speed is
    removed from the player if the time remaining on speed is lower then 75 ticks
    and is speed 3 or lower
-Natural Hunter's excitement resource now decreases by 2 if the feline hits an
    entity with a normal attack and ending the power with said hit will not give
    slowness
-Ending Natural Hunter power will remove the temporary speed buff (bow and melee kills)
-Natural Hunter's speed buff only stacks up to speed 2 now (was 3)